### PR TITLE
[#73] Checkstyle will throw error on violations / fixes all violation…

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -22,7 +22,7 @@
 <module name="Checker">
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
 

--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/db/entities/Identifier.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/db/entities/Identifier.java
@@ -11,12 +11,11 @@
 
 package org.kitodo.mediaserver.core.db.entities;
 
-import org.apache.commons.lang.StringUtils;
-
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Entity for identifiers for digitized works.

--- a/kitodo-mediaserver-importer/src/main/java/org/kitodo/mediaserver/importer/config/ImporterConfiguration.java
+++ b/kitodo-mediaserver-importer/src/main/java/org/kitodo/mediaserver/importer/config/ImporterConfiguration.java
@@ -13,20 +13,18 @@ package org.kitodo.mediaserver.importer.config;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.kitodo.mediaserver.core.api.IDataReader;
 import org.kitodo.mediaserver.core.api.IMetsReader;
 import org.kitodo.mediaserver.core.api.IReadResultParser;
-import org.kitodo.mediaserver.importer.processors.WorkDataReader;
-import org.kitodo.mediaserver.core.processors.XsltMetsReader;
 import org.kitodo.mediaserver.core.processors.SimpleList2MapParser;
+import org.kitodo.mediaserver.core.processors.XsltMetsReader;
 import org.kitodo.mediaserver.core.util.MediaServerUtils;
 import org.kitodo.mediaserver.importer.api.IImportValidation;
 import org.kitodo.mediaserver.importer.api.IMetsValidation;
+import org.kitodo.mediaserver.importer.processors.WorkDataReader;
 import org.kitodo.mediaserver.importer.util.ImporterUtils;
 import org.kitodo.mediaserver.importer.validators.FileOccurrenceValidation;
 import org.kitodo.mediaserver.importer.validators.ImportDataAndFilesValidation;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;

--- a/kitodo-mediaserver-importer/src/main/java/org/kitodo/mediaserver/importer/control/ImporterFlowControl.java
+++ b/kitodo-mediaserver-importer/src/main/java/org/kitodo/mediaserver/importer/control/ImporterFlowControl.java
@@ -12,17 +12,12 @@
 package org.kitodo.mediaserver.importer.control;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-import org.apache.commons.io.FilenameUtils;
+import org.kitodo.mediaserver.core.api.IDataReader;
 import org.kitodo.mediaserver.core.db.entities.Work;
 import org.kitodo.mediaserver.core.exceptions.ValidationException;
 import org.kitodo.mediaserver.importer.api.IImportValidation;
-import org.kitodo.mediaserver.importer.api.IMetsValidation;
 import org.kitodo.mediaserver.importer.config.ImporterProperties;
 import org.kitodo.mediaserver.importer.exceptions.ImporterException;
-import org.kitodo.mediaserver.core.api.IDataReader;
-import org.kitodo.mediaserver.core.db.entities.Work;
 import org.kitodo.mediaserver.importer.util.ImporterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
…s too

This sets checkstyle rules to throw errors instead of warnings. This will cause `mvn checkstyle:check` to fail if there are checkstyle violations.