### PR TITLE
[#128] Execution of configurable actions after import

### DIFF
--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/actions/TestAction.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/actions/TestAction.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+package org.kitodo.mediaserver.core.actions;
+
+import java.util.Map;
+import org.kitodo.mediaserver.core.api.IAction;
+import org.kitodo.mediaserver.core.db.entities.Work;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Example action.
+ */
+@Component("testAction")
+public class TestAction implements IAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestAction.class);
+
+    /**
+     * Performs an action for test purposes.
+     *
+     * @param work      a work entity
+     * @param parameter a map of parameter
+     * @return an object with the result of the action, if any.
+     * @throws Exception by fatal errors
+     */
+    @Override
+    public Object perform(Work work, Map<String, String> parameter) throws Exception {
+
+        LOGGER.info("TestAction performed on Work: " + work.getId() + " with parameter map: " + parameter);
+        return null;
+    }
+}

--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/converter/ActionListPropertyConverter.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/converter/ActionListPropertyConverter.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+package org.kitodo.mediaserver.core.config.converter;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Convert empty property in YAML to empty Map.
+ * Parses this:
+ * {@code
+ *   actionsBeforeIndexing:  -->  Map<String, Map<String, String>>
+ * }
+ */
+@Component
+@ConfigurationPropertiesBinding
+public class ActionListPropertyConverter implements Converter<String, Map<String, Map<String, String>>> {
+
+    /**
+     * Creates an entry if requested in a properties class and none given in the yaml configuration.
+     *
+     * @param source the yaml key
+     * @return a map with the source as key
+     */
+    @Override
+    public Map<String, Map<String, String>> convert(String source) {
+
+        Map<String, Map<String, String>> map = new HashMap<>();
+
+        if (StringUtils.hasText(source)) {
+            /*
+             * parse action name without ending colon:
+             *
+             *   actionsBeforeIndexing:
+             *   - testAction  -->  Map<String, String>
+             */
+            map.put(source, new HashMap<>());
+        }
+
+        return map;
+    }
+}

--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/converter/ActionParameterPropertyConverter.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/converter/ActionParameterPropertyConverter.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+package org.kitodo.mediaserver.core.config.converter;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert empty property in YAML to empty Map.
+ * Parses this:
+ * {@code
+ *  actionsBeforeIndexing:
+ *  - testAction:  -->  Map<String, String>
+ * }
+ */
+@Component
+@ConfigurationPropertiesBinding
+public class ActionParameterPropertyConverter implements Converter<String, Map<String, String>> {
+
+    /**
+     * Creates an empty map if requested in the properties class and none given in the yaml configuration.
+     *
+     * @param source ignored
+     * @return an empty map
+     */
+    @Override
+    public Map<String, String> convert(String source) {
+        return new HashMap<>();
+    }
+}

--- a/kitodo-mediaserver-core/src/main/resources/config/default.yml
+++ b/kitodo-mediaserver-core/src/main/resources/config/default.yml
@@ -68,8 +68,13 @@ importer:
   workIdRegex: "[\\w-]+"
   cron: 0 5 2 * * *
   indexWorkAfterImport: true
+
   validationFileGrps:
   - ORIGINAL
+
+  actionsBeforeIndexing:
+  actionsAfterSuccessfulIndexing:
+  actionsToRequestAsynchronously:
 
 
 ui:

--- a/kitodo-mediaserver-importer/src/main/java/org/kitodo/mediaserver/importer/config/ImporterProperties.java
+++ b/kitodo-mediaserver-importer/src/main/java/org/kitodo/mediaserver/importer/config/ImporterProperties.java
@@ -12,6 +12,7 @@
 package org.kitodo.mediaserver.importer.config;
 
 import java.util.List;
+import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,6 +34,9 @@ public class ImporterProperties {
     private String cron;
     private boolean indexWorkAfterImport;
     private List<String> validationFileGrps;
+    private List<Map<String, Map<String, String>>> actionsBeforeIndexing;
+    private List<Map<String, Map<String, String>>> actionsAfterSuccessfulIndexing;
+    private List<Map<String, Map<String, String>>> actionsToRequestAsynchronously;
 
     public String getHotfolderPath() {
         return hotfolderPath;
@@ -120,5 +124,29 @@ public class ImporterProperties {
 
     public void setIndexWorkAfterImport(boolean indexWorkAfterImport) {
         this.indexWorkAfterImport = indexWorkAfterImport;
+    }
+
+    public List<Map<String, Map<String, String>>> getActionsBeforeIndexing() {
+        return actionsBeforeIndexing;
+    }
+
+    public void setActionsBeforeIndexing(List<Map<String, Map<String, String>>> actionsBeforeIndexing) {
+        this.actionsBeforeIndexing = actionsBeforeIndexing;
+    }
+
+    public List<Map<String, Map<String, String>>> getActionsAfterSuccessfulIndexing() {
+        return actionsAfterSuccessfulIndexing;
+    }
+
+    public void setActionsAfterSuccessfulIndexing(List<Map<String, Map<String, String>>> actionsAfterSuccessfulIndexing) {
+        this.actionsAfterSuccessfulIndexing = actionsAfterSuccessfulIndexing;
+    }
+
+    public List<Map<String, Map<String, String>>> getActionsToRequestAsynchronously() {
+        return actionsToRequestAsynchronously;
+    }
+
+    public void setActionsToRequestAsynchronously(List<Map<String, Map<String, String>>> actionsToRequestAsynchronously) {
+        this.actionsToRequestAsynchronously = actionsToRequestAsynchronously;
     }
 }


### PR DESCRIPTION
I've kept the names of the converters after all; couldn't think of anything else to call them