### PR TITLE
87 notifier

### DIFF
--- a/kitodo-mediaserver-core/pom.xml
+++ b/kitodo-mediaserver-core/pom.xml
@@ -60,6 +60,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/api/INotifier.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/api/INotifier.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+package org.kitodo.mediaserver.core.api;
+
+import java.util.List;
+import javax.mail.MessagingException;
+
+/**
+ * Interface for a notification service.
+ */
+public interface INotifier {
+
+    /**
+     * Appends a message to a notification.
+     *
+     * @param buffer The notification buffer
+     * @param message the message
+     */
+    void add(StringBuffer buffer, String message);
+
+    /**
+     * Sends a notification.
+     */
+    void send(StringBuffer buffer, String subject, List<String> recipients) throws MessagingException;
+}

--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/ConversionProperties.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/ConversionProperties.java
@@ -22,11 +22,20 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "conversion")
 public class ConversionProperties {
 
+    private List<String> notificationEmail;
     private List<String> pathExtractionPatterns;
     private boolean useGraphicsMagick;
 
     public void setPathExtractionPatterns(List<String> pathExtractionPatterns) {
         this.pathExtractionPatterns = pathExtractionPatterns;
+    }
+
+    public List<String> getNotificationEmail() {
+        return notificationEmail;
+    }
+
+    public void setNotificationEmail(List<String> notificationEmail) {
+        this.notificationEmail = notificationEmail;
     }
 
     public List<String> getPathExtractionPatterns() {

--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/CoreConfiguration.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/CoreConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+package org.kitodo.mediaserver.core.config;
+
+import org.kitodo.mediaserver.core.util.Notifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class CoreConfiguration {
+    @Bean
+    public JavaMailSender getMailSender() {
+        return new JavaMailSenderImpl();
+    }
+
+    @Bean
+    public Notifier notifier() {
+        return new Notifier();
+    }
+}

--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/NotifierProperties.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/config/NotifierProperties.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+package org.kitodo.mediaserver.core.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Properties class for the notifier configuration.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "notifier")
+public class NotifierProperties {
+
+    private String emailFrom;
+    private String timestampFormat;
+
+    public String getEmailFrom() {
+        return emailFrom;
+    }
+
+    public void setEmailFrom(String emailFrom) {
+        this.emailFrom = emailFrom;
+    }
+
+    public String getTimestampFormat() {
+        return timestampFormat;
+    }
+
+    public void setTimestampFormat(String timestampFormat) {
+        this.timestampFormat = timestampFormat;
+    }
+}

--- a/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/util/Notifier.java
+++ b/kitodo-mediaserver-core/src/main/java/org/kitodo/mediaserver/core/util/Notifier.java
@@ -1,0 +1,101 @@
+/*
+ * (c) Kitodo. Key to digital objects e. V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo project.
+ *
+ * It is licensed under GNU General Public License version 3 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+package org.kitodo.mediaserver.core.util;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import org.kitodo.mediaserver.core.api.INotifier;
+import org.kitodo.mediaserver.core.config.NotifierProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+/**
+ * Simple notifier.
+ */
+public class Notifier implements INotifier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Notifier.class);
+
+    private JavaMailSender mailSender;
+    private NotifierProperties notifierProperties;
+
+    @Autowired
+    public void setNotifierProperties(NotifierProperties notifierProperties) {
+        this.notifierProperties = notifierProperties;
+    }
+
+    @Autowired
+    public void setMailSender(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public StringBuffer init() {
+        return new StringBuffer();
+    }
+
+    /**
+     * Appends a message to a notification.
+     *
+     * @param buffer The notification buffer
+     * @param message the message
+     */
+    @Override
+    public void add(StringBuffer buffer, String message) {
+        buffer.append(getTime());
+        buffer.append("\t\t");
+        buffer.append(message);
+        buffer.append("\n");
+    }
+
+    /**
+     * Sends a notification.
+     *
+     * @param buffer The notification buffer that holds the concatenated notification
+     * @param subject The mail subject
+     */
+    @Override
+    public void send(StringBuffer buffer, String subject, List<String> recipients) throws MessagingException {
+
+        if (recipients.size() > 0) {
+            String [] emailTo = recipients.toArray(new String[0]);
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper mailHelper = new MimeMessageHelper(message, false, "utf-8");
+            mailHelper.setSubject(subject);
+            mailHelper.setText(buffer.toString());
+            mailHelper.setFrom(notifierProperties.getEmailFrom());
+            mailHelper.setTo(emailTo);
+            mailSender.send(message);
+            LOGGER.info("Sent notification email to " + String.join(",", emailTo));
+        }
+    }
+
+    /**
+     * Returns string with current datetime in a configured format.
+     */
+    protected String getTime() {
+        String format = notifierProperties.getTimestampFormat();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format)
+                .withLocale(Locale.getDefault()).withZone(ZoneId.systemDefault());
+
+        return formatter.format(Instant.now());
+    }
+
+
+}

--- a/kitodo-mediaserver-core/src/main/resources/config/default.yml
+++ b/kitodo-mediaserver-core/src/main/resources/config/default.yml
@@ -19,6 +19,16 @@ spring:
         dialect: org.hibernate.dialect.MySQL57Dialect
   main:
     banner-mode: "off"
+  mail:
+    host: localhost
+    port: 25
+    username:
+    password:
+    smtp:
+      auth: false
+      starttls:
+        enable: false
+        required: false
 
 logging:
   level:
@@ -30,6 +40,11 @@ logging:
     console:
     file: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger - %msg%n"
   path: /usr/local/kitodo/mediaserver/
+
+notifier:
+  emailFrom: "kitodo@example.org"
+  timestampFormat: "yyyy-MM-dd HH:mm:ss"
+  # Recipients are set in the modules via <notification>
 
 fileserver:
   rootUrl: https://example.com/files/
@@ -44,6 +59,7 @@ fileserver:
     disabled: 0.0.0.0/32,::/128
 
 conversion:
+  notificationEmail:
   jpeg:
     defaultSize: 1000
   useGraphicsMagick: false
@@ -92,7 +108,8 @@ importer:
   workIdRegex: "[\\w-]+"
   cron: 0 5 2 * * *
   indexWorkAfterImport: true
-
+  notificationEmail:
+    - admin@example.org
   validationFileGrps:
   - ORIGINAL
 

--- a/kitodo-mediaserver-fileserver/src/main/java/org/kitodo/mediaserver/fileserver/config/FileserverConfiguration.java
+++ b/kitodo-mediaserver-fileserver/src/main/java/org/kitodo/mediaserver/fileserver/config/FileserverConfiguration.java
@@ -19,8 +19,10 @@ import org.kitodo.mediaserver.core.api.IMetsReader;
 import org.kitodo.mediaserver.core.api.IReadResultParser;
 import org.kitodo.mediaserver.core.api.IWatermarker;
 import org.kitodo.mediaserver.core.config.ConversionProperties;
+import org.kitodo.mediaserver.core.config.CoreConfiguration;
 import org.kitodo.mediaserver.core.config.FileserverProperties;
 import org.kitodo.mediaserver.core.config.MetsProperties;
+import org.kitodo.mediaserver.core.config.NotifierProperties;
 import org.kitodo.mediaserver.core.conversion.SimpleIMSingleFileConverter;
 import org.kitodo.mediaserver.core.processors.PatternExtractor;
 import org.kitodo.mediaserver.core.processors.SimpleList2MapParser;
@@ -41,7 +43,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
  * Spring configuration of the fileserver module.
  */
 @Configuration
-@Import({ConversionProperties.class, FileserverProperties.class, MetsProperties.class})
+@Import({CoreConfiguration.class, ConversionProperties.class, FileserverProperties.class, MetsProperties.class, NotifierProperties.class})
 @EnableJpaRepositories("org.kitodo.mediaserver.core.db.repositories")
 @EntityScan("org.kitodo.mediaserver.core.db.entities")
 public class FileserverConfiguration {


### PR DESCRIPTION
Notification emails. Configured via yml properties (base configuration with "notifier" and recipients via "notificationEmail" property within "conversion", for example).

The Core Configuration class is needed for integrating the mailer and the notifier. Example usage is given in SingleFileConvertAction and could be extended to the importer module.